### PR TITLE
Add lookup table for each square on the board

### DIFF
--- a/src/main/java/com/github/jamesh321/chessengine/Board.java
+++ b/src/main/java/com/github/jamesh321/chessengine/Board.java
@@ -190,7 +190,7 @@ public class Board {
      * @return the piece at that square, or null if the square is empty
      */
     public Piece getPieceAtSquare(int square) {
-        long boardSquare = 1L << 63 - square;
+        long boardSquare = LookupTables.BITBOARD_SQUARES[square];
         for (Piece piece : Piece.values()) {
             if ((boardSquare & bitboards[piece.getIndex()]) != 0) {
                 return piece;

--- a/src/main/java/com/github/jamesh321/chessengine/Fen.java
+++ b/src/main/java/com/github/jamesh321/chessengine/Fen.java
@@ -81,7 +81,7 @@ public final class Fen {
                 }
 
                 if (piece != null) {
-                    board.setBitboard(piece, board.getBitboard(piece) | 1L << (63 - square));
+                    board.setBitboard(piece, board.getBitboard(piece) | LookupTables.BITBOARD_SQUARES[square]);
                     square += 1;
                 } else {
                     square += Character.getNumericValue(ranks[rank].charAt(j));

--- a/src/main/java/com/github/jamesh321/chessengine/LookupTables.java
+++ b/src/main/java/com/github/jamesh321/chessengine/LookupTables.java
@@ -158,7 +158,7 @@ public final class LookupTables {
             if (toFile < 0 || toFile > 7 || toRank < 0 || toRank > 7) {
                 continue;
             }
-            moves |= 1L << (63 - (toRank * 8 + toFile));
+            moves |= BITBOARD_SQUARES[toRank * 8 + toFile];
         }
         return moves;
     }
@@ -181,7 +181,7 @@ public final class LookupTables {
             if (file < 0 || file > 7 || rank < 0 || rank > 7) {
                 break;
             }
-            ray |= 1L << (63 - (rank * 8 + file));
+            ray |= BITBOARD_SQUARES[rank * 8 + file];
         }
         return ray;
     }

--- a/src/main/java/com/github/jamesh321/chessengine/MoveExecutor.java
+++ b/src/main/java/com/github/jamesh321/chessengine/MoveExecutor.java
@@ -30,8 +30,8 @@ public final class MoveExecutor {
     public static void makeMove(Board board, Move move) {
         int from = move.getFrom();
         int to = move.getTo();
-        long fromMask = 1L << 63 - from;
-        long toMask = 1L << 63 - to;
+        long fromMask = LookupTables.BITBOARD_SQUARES[from];
+        long toMask = LookupTables.BITBOARD_SQUARES[to];
         Piece fromPiece = board.getPieceAtSquare(from);
         Piece toPiece = board.getPieceAtSquare(to);
 


### PR DESCRIPTION
This pull request refactors the chess engine to use a precomputed lookup table (`BITBOARD_SQUARES`) for bitboard square calculations, replacing repeated bit-shifting operations. This change improves code readability and potentially enhances performance by centralizing square computations.

### Refactoring to use `BITBOARD_SQUARES` lookup table:

#### Lookup table initialization:
* `src/main/java/com/github/jamesh321/chessengine/LookupTables.java`: Added the `BITBOARD_SQUARES` array and implemented the `initialiseBitboardSquares` method to precompute bitboard values for all squares. This method is invoked during static initialization.

#### Replacing bit-shifting operations:
* `src/main/java/com/github/jamesh321/chessengine/Board.java`: Replaced manual bit-shifting with `BITBOARD_SQUARES` for square computations in `getPieceAtSquare`.
* `src/main/java/com/github/jamesh321/chessengine/Fen.java`: Updated `loadBoard` to use `BITBOARD_SQUARES` for setting bitboards.
* `src/main/java/com/github/jamesh321/chessengine/MoveExecutor.java`: Refactored `makeMove` to use `BITBOARD_SQUARES` for move masks.
* `src/main/java/com/github/jamesh321/chessengine/MoveGenerator.java`: Replaced bit-shifting with `BITBOARD_SQUARES` in various methods, including pawn move generation, attack checks, and ray calculations.
* `src/main/java/com/github/jamesh321/chessengine/LookupTables.java`: Refactored `generateMovesForDirections` and `generateRay` to use `BITBOARD_SQUARES` for directional and ray calculations.

This refactoring centralizes square computations, making the code more maintainable and reducing the risk of errors associated with manual bit-shifting.